### PR TITLE
Update for the latest mach-glfw version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@
 
 zig-cache/
 zig-out/
-shaders/triangle_vert.spv
-shaders/triangle_frag.spv

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is an example for how to use [mach-glfw](https://github.com/hexops/mach-glfw) and [vulkan-zig](https://github.com/snektron/vulkan-zig) together to create a basic Vulkan window.
 
-This is nearly a 1:1 copy of the [vulkan-zig example](https://github.com/snektron/vulkan-zig) by @snektron, the only difference is using [mach-glfw](https://github.com/hexops/mach-glfw).
+This is nearly a 1:1 copy of the [vulkan-zig example](https://github.com/Snektron/vulkan-zig/tree/master/examples) by @snektron, the only difference is using [mach-glfw](https://github.com/hexops/mach-glfw).
 
-<img width="912" alt="image" src="https://user-images.githubusercontent.com/3173176/139573985-d862f35a-e78e-40c2-bc0c-9c4fb68d6ecd.png">
+![](https://user-images.githubusercontent.com/3173176/139573985-d862f35a-e78e-40c2-bc0c-9c4fb68d6ecd.png)
 
 ## Getting started
 
@@ -15,14 +15,16 @@ You must install the LunarG Vulkan SDK: https://vulkan.lunarg.com/sdk/home
 ### Clone the repository and dependencies
 
 ```sh
-git clone --recurse-submodules https://github.com/hexops/mach-glfw-vulkan-example
+git clone https://github.com/hexops/mach-glfw-vulkan-example
+
+cd mach-glfw-vulkan-example
 ```
 
 ### Ensure glslc is on your PATH
 
 On MacOS, you may e.g. place the following in your `~/.zprofile` file:
 
-```
+```sh
 export PATH=$PATH:$HOME/VulkanSDK/1.2.189.0/macOS/bin/
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -1,15 +1,19 @@
 const std = @import("std");
-const glfw = @import("mach_glfw");
 
-pub fn build(b: *std.build.Builder) !void {
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
+
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
-
-    const vulkan_dep = b.dependency("vulkan", .{});
-    const vulkan_mod = vulkan_dep.module("vulkan-zig-generated");
-
-    const glfw_dep = b.dependency("mach_glfw", .{ .target = target, .optimize = optimize });
-    const glfw_mod = glfw_dep.module("mach-glfw");
 
     const exe = b.addExecutable(.{
         .name = "mach-glfw-vulkan-example",
@@ -17,34 +21,61 @@ pub fn build(b: *std.build.Builder) !void {
         .target = target,
         .optimize = optimize,
     });
-    exe.main_pkg_path = .{ .path = "." };
-    try glfw.link(b, exe);
-    exe.addModule("vulkan", vulkan_mod);
-    exe.addModule("glfw", glfw_mod);
+
+    // Use mach-glfw.
+    const mach_glfw_dep = b.dependency("mach-glfw", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("mach-glfw", mach_glfw_dep.module("mach-glfw"));
+
+    // Use pre-generated Vulkan bindings.
+    const vulkan_dep = b.dependency("vulkan-zig-generated", .{});
+    exe.root_module.addImport("vulkan", vulkan_dep.module("vulkan-zig-generated"));
+
+    // Compile the vertex shader at build time so that it can be imported with '@embedFile'.
+    const compile_vert_shader = b.addSystemCommand(&.{"glslc"});
+    compile_vert_shader.addFileArg(.{ .path = "shaders/triangle.vert" });
+    compile_vert_shader.addArgs(&.{ "--target-env=vulkan1.1", "-o" });
+    const triangle_vert_spv = compile_vert_shader.addOutputFileArg("triangle_vert.spv");
+    exe.root_module.addAnonymousImport("triangle_vert", .{
+        .root_source_file = triangle_vert_spv,
+    });
+
+    // Ditto for the fragment shader.
+    const compile_frag_shader = b.addSystemCommand(&.{"glslc"});
+    compile_frag_shader.addFileArg(.{ .path = "shaders/triangle.frag" });
+    compile_frag_shader.addArgs(&.{ "--target-env=vulkan1.1", "-o" });
+    const triangle_frag_spv = compile_frag_shader.addOutputFileArg("triangle_frag.spv");
+    exe.root_module.addAnonymousImport("triangle_frag", .{
+        .root_source_file = triangle_frag_spv,
+    });
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
     b.installArtifact(exe);
 
-    const compile_vert_shader = b.addSystemCommand(&.{
-        "glslc",
-        "shaders/triangle.vert",
-        "--target-env=vulkan1.1",
-        "-o",
-        "shaders/triangle_vert.spv",
-    });
-    const compile_frag_shader = b.addSystemCommand(&.{
-        "glslc",
-        "shaders/triangle.frag",
-        "--target-env=vulkan1.1",
-        "-o",
-        "shaders/triangle_frag.spv",
-    });
-
-    exe.step.dependOn(&compile_vert_shader.step);
-    exe.step.dependOn(&compile_frag_shader.step);
-
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
     const run_cmd = b.addRunArtifact(exe);
-    run_cmd.step.dependOn(b.getInstallStep());
-    if (b.args) |args| run_cmd.addArgs(args);
 
+    // By making the run step depend on the install step, it will be run from the
+    // installation directory rather than directly from within the cache directory.
+    // This is not necessary, however, if the application depends on other installed
+    // files, this ensures they will be present and in the expected location.
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,38 +1,18 @@
 .{
     .name = "mach-glfw-vulkan-example",
-    .version = "0.1.0",
+    .version = "0.0.0",
+    .minimum_zig_version = "0.12.0-dev.2063+804cee3b9",
     .dependencies = .{
-        .vulkan = .{
-            .url = "https://pkg.machengine.org/vulkan-zig-generated/5145693a4faacfde4b9502ff96a344d208a65949.tar.gz",
-            .hash = "1220aff94214342c77f1c4477d524f31c45e09c2472266a3af9a22502ae41c55b48e",
+        .@"mach-glfw" = .{
+            .url = "https://pkg.machengine.org/mach-glfw/1a9a03399058fd83f7fbb597f3f8304007ff6a3c.tar.gz",
+            .hash = "1220b4d58ec6cf53abfd8d7547d39afb9bffa41822d4d58f52625230466e51cc93bb",
         },
-        .mach_glfw = .{
-            .url = "https://pkg.machengine.org/mach-glfw/58a16012c33b047b9468cccb53ecd95835456121.tar.gz",
-            .hash = "1220dcf8c006b5bd91bb55c732eac6d95afe16247058f31348e1e2e071dfca7923db",
+        .@"vulkan-zig-generated" = .{
+            .url = "https://pkg.machengine.org/vulkan-zig-generated/78b3c3838ffcb64d537b4af340c9d3fcc41944ce.tar.gz",
+            .hash = "1220c4a2a02e0bd81827225deea58b18f5ea9373cf932c073b977469e298eef1f54f",
         },
-        .xcode_frameworks = .{
-            .url = "https://github.com/hexops/xcode-frameworks-pkg/archive/d486474a6af7fafd89e8314e0bf7eca4709f811b.tar.gz",
-            .hash = "1220293eae4bf67a7c27a18a8133621337cde91a97bc6859a9431b3b2d4217dfb5fb",
-        },
-        .glfw = .{
-            .url = "https://pkg.machengine.org/glfw/bad964824403ba34c935a90013024957dae795aa.tar.gz",
-            .hash = "1220fe0763e9722d56d3f93f8740e077fccf338d9697f08239d79a1ee27ae5833e62",
-        },
-        .direct3d_headers = .{
-            .url = "https://pkg.machengine.org/direct3d-headers/c02ba4ba3f9473560e41487090ee6bfbbc44c75b.tar.gz",
-            .hash = "1220b4a3be5bd4d0c4a206c909b07579070f4fa8c83dd82170ed1db846b0eea1ae9d",
-        },
-        .vulkan_headers = .{
-            .url = "https://pkg.machengine.org/vulkan-headers/0212dd8b71531d0cec8378ce8fb1721a0df7420a.tar.gz",
-            .hash = "1220a8b642edf8ef522e468cfe9a1803507472461b1041be717294ca484d1361afb0",
-        },
-        .wayland_headers = .{
-            .url = "https://pkg.machengine.org/wayland-headers/509275fb6222181a97026c884d411bd013da680b.tar.gz",
-            .hash = "12202cf6230788d948e5ee2afa26d4f6cc4994ae1bf0c1c832535b920717a1174223",
-        },
-        .x11_headers = .{
-            .url = "https://pkg.machengine.org/x11-headers/991ad9bf599df04aaa5332e536712a8476838ee3.tar.gz",
-            .hash = "12205bd95b9cc9cb08dd6b55f5842d8fae67a12eed01092c54f021060931815f711e",
-        },
+    },
+    .paths = .{
+        "",
     },
 }

--- a/src/graphics_context.zig
+++ b/src/graphics_context.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const glfw = @import("mach-glfw");
 const vk = @import("vulkan");
-const glfw = @import("glfw");
 const Allocator = std.mem.Allocator;
 
 const required_device_extensions = [_][*:0]const u8{

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
+const glfw = @import("mach-glfw");
 const vk = @import("vulkan");
-const glfw = @import("glfw");
 const GraphicsContext = @import("graphics_context.zig").GraphicsContext;
 const Swapchain = @import("swapchain.zig").Swapchain;
-const triangle_vert = @embedFile("../shaders/triangle_vert.spv");
-const triangle_frag = @embedFile("../shaders/triangle_frag.spv");
+const triangle_vert = @embedFile("triangle_vert");
+const triangle_frag = @embedFile("triangle_frag");
 const Allocator = std.mem.Allocator;
 
 const app_name = "mach-glfw + vulkan-zig = triangle";
@@ -86,7 +86,7 @@ pub fn main() !void {
     const render_pass = try createRenderPass(&gc, swapchain);
     defer gc.vkd.destroyRenderPass(gc.dev, render_pass, null);
 
-    var pipeline = try createPipeline(&gc, pipeline_layout, render_pass);
+    const pipeline = try createPipeline(&gc, pipeline_layout, render_pass);
     defer gc.vkd.destroyPipeline(gc.dev, pipeline, null);
 
     var framebuffers = try createFramebuffers(&gc, allocator, render_pass, swapchain);


### PR DESCRIPTION
- Gets the project working with the latest mach-glfw and the 2024.1.0-mach version of Zig.
- Updates boilerplate to match recent changes to `zig init`.
- Removes transitive dependencies that are no longer needed.
- Fixes the system commands to make proper use of Zig build system caching.

I didn't touch any program code outside of what was necessary to get it to compile. Please verify that it works on macOS before merging.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.